### PR TITLE
Fix zero-concurrency validation and DI binding bug; CI/docs updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
       - run: vendor/bin/phpunit --coverage-clover=coverage.xml
         env:
           XDEBUG_MODE: coverage
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.php }}
+          path: coverage.xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
       - run: composer update --no-progress --no-interaction
-      - run: composer outdated -D --strict --ignore=phpunit/phpunit --ignore=illuminate/support --ignore=illuminate/container
+      - run: composer outdated -D --strict --ignore=phpunit/phpunit
 
   phpunit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
       - run: composer update --no-progress --no-interaction
-      - run: composer outdated -D --strict --ignore=phpunit/phpunit
+      - run: composer outdated -D --strict
 
   phpunit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,11 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
+          ini-values: zend.assertions=1
       - run: composer update --no-progress --no-interaction
       - run: vendor/bin/phpunit --coverage-clover=coverage.xml
         env:
           XDEBUG_MODE: coverage
-      - uses: actions/upload-artifact@v4
-        with:
-          name: coverage-${{ matrix.php }}
-          path: coverage.xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
       - run: composer update --no-progress --no-interaction
-      - run: composer outdated -D --strict --ignore=phpunit/phpunit --ignore=illuminate/support
+      - run: composer outdated -D --strict --ignore=phpunit/phpunit --ignore=illuminate/support --ignore=illuminate/container
 
   phpunit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.2', '8.3', '8.4', '8.5']
     name: Composer PHP ${{ matrix.php }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.2', '8.3', '8.4', '8.5']
     name: PHPUnit PHP ${{ matrix.php }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -38,17 +38,17 @@ jobs:
         env:
           XDEBUG_MODE: coverage
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
   phpstan:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.2', '8.3', '8.4', '8.5']
     name: PHPStan PHP ${{ matrix.php }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -60,10 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.2', '8.3', '8.4', '8.5']
     name: PHPStan Lowest PHP ${{ matrix.php }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -75,6 +75,6 @@ jobs:
     runs-on: ubuntu-latest
     name: PHPCS
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: composer update --no-progress --no-interaction
       - run: vendor/bin/phpcs src --standard=PSR2 -n

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-
+### Fixed
+- `MultitronFactory::setDefaultConcurrency()` no longer accepts `0`, which previously passed validation but crashed later with an unrelated exception
 
 ## [1.2.0] - 2026-03-09
 ### Improved

--- a/README.md
+++ b/README.md
@@ -24,13 +24,12 @@
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Usage](#usage)
-  - [Basic Example](#usage)
-  - [Running Tasks](#usage)
   - [Central Cache](#central-cache)
   - [Reporting Progress](#reporting-progress)
   - [Partitioned Tasks](#partitioned-tasks)
   - [Accessing CLI Options](#accessing-cli-options)
   - [Custom Progress Output](#custom-progress-output)
+- [Troubleshooting](#troubleshooting)
 - [Contributing](#contribute-to-multitron)
 - [License](#license)
 
@@ -144,6 +143,12 @@ php bin/console app:tasks -m 512M
 ```
 
 You can disable colors with `--no-colors` and switch off interactive table rendering using `--interactive=no`. The default `--interactive=detect` automatically falls back to plain output when run in CI.
+
+Multitron warns when available system memory drops below a threshold (in MB) via `--low-memory-warn`. It defaults to 1024 MB; pass `0` to disable the warning:
+
+```bash
+php bin/console app:tasks --low-memory-warn=512
+```
 
 ### Central Cache
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.0.x   | :white_check_mark: |
+| 1.x     | :white_check_mark: |
 | < 1.0   | :x:                |
 
 ## Reporting a Vulnerability

--- a/composer.json
+++ b/composer.json
@@ -54,8 +54,8 @@
         "phpunit/phpunit": "^11.5",
         "squizlabs/php_codesniffer": "^3.13|^4.0",
         "symfony/dependency-injection": "^7.3|^8.0",
-        "illuminate/support": "^12",
-        "illuminate/container": "^12",
+        "illuminate/support": "^12|^13",
+        "illuminate/container": "^12|^13",
         "pimple/pimple": "^3.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "nette/di": "^3.2",
         "phpstan/phpstan": "^2.1",
         "contributte/psr11-container-interface": "^0.7.0",
-        "phpunit/phpunit": "^11.5",
+        "phpunit/phpunit": "^11.5|^12|^13",
         "squizlabs/php_codesniffer": "^3.13|^4.0",
         "symfony/dependency-injection": "^7.3|^8.0",
         "illuminate/support": "^12|^13",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,4 @@
 parameters:
     level: 9
+    # pcntl/pthreads availability differs by runner+PHP version, so this rule fires inconsistently across the CI matrix
+    reportUnmatchedIgnoredErrors: false

--- a/src/Bridge/Native/MultitronFactory.php
+++ b/src/Bridge/Native/MultitronFactory.php
@@ -203,7 +203,7 @@ final class MultitronFactory
 
     public function setDefaultConcurrency(?int $defaultConcurrency): self
     {
-        if ($defaultConcurrency < 0) {
+        if ($defaultConcurrency !== null && $defaultConcurrency < 1) {
             throw new InvalidArgumentException('Default concurrency must be a positive integer or null.');
         }
         $this->defaultConcurrency = $defaultConcurrency;

--- a/src/Bridge/Nette/MultitronExtension.php
+++ b/src/Bridge/Nette/MultitronExtension.php
@@ -8,6 +8,7 @@ use Multitron\Bridge\Native\MultitronFactory;
 use Multitron\Console\TaskCommandDeps;
 use Multitron\Console\WorkerCommand;
 use Nette\DI\CompilerExtension;
+use Nette\DI\Definitions\Reference;
 
 final class MultitronExtension extends CompilerExtension
 {
@@ -19,12 +20,16 @@ final class MultitronExtension extends CompilerExtension
             ->setType(MultitronFactory::class)
             ->setCreator(MultitronFactory::class);
 
+        $factoryName = $factory->getName();
+        assert($factoryName !== null);
+        $factoryRef = new Reference($factoryName);
+
         $builder->addDefinition($this->prefix('commandDeps'))
             ->setType(TaskCommandDeps::class)
-            ->setCreator([$factory, 'getTaskCommandDeps']);
+            ->setCreator([$factoryRef, 'getTaskCommandDeps']);
 
         $builder->addDefinition($this->prefix('workerCommand'))
             ->setType(WorkerCommand::class)
-            ->setFactory([$factory, 'getWorkerCommand']);
+            ->setFactory([$factoryRef, 'getWorkerCommand']);
     }
 }

--- a/src/Console/TableRenderer.php
+++ b/src/Console/TableRenderer.php
@@ -127,9 +127,9 @@ final class TableRenderer
         $minutes = floor($time / 60);
         $seconds = fmod($time, 60);
         if ($minutes >= 10) {
-            $out = sprintf('%d:%d', $minutes, $seconds);
+            $out = sprintf('%d:%02d', $minutes, $seconds);
         } elseif ($minutes > 0) {
-            $out = sprintf('%dm%ds', $minutes, $seconds);
+            $out = sprintf('%dm%02ds', $minutes, $seconds);
         } else {
             $out = number_format($seconds, 1) . 's';
         }

--- a/src/Console/TaskCommand.php
+++ b/src/Console/TaskCommand.php
@@ -88,7 +88,7 @@ abstract class TaskCommand extends Command
         $builder = $this->builderFactory->create();
         $pattern = $input?->getArgument('pattern');
         if (is_string($pattern) && trim($pattern) !== '') {
-            $includeDeps = (bool)($input?->getOption(self::OPTION_DEPS) ?? true);
+            $includeDeps = (bool)($input->getOption(self::OPTION_DEPS) ?? true);
             $node = $builder->patternFilter(
                 'root',
                 $pattern,

--- a/src/Console/TaskCommand.php
+++ b/src/Console/TaskCommand.php
@@ -87,7 +87,7 @@ abstract class TaskCommand extends Command
 
         $builder = $this->builderFactory->create();
         $pattern = $input?->getArgument('pattern');
-        if (is_string($pattern) && trim($pattern) !== '') {
+        if ($input !== null && is_string($pattern) && trim($pattern) !== '') {
             $includeDeps = (bool)($input->getOption(self::OPTION_DEPS) ?? true);
             $node = $builder->patternFilter(
                 'root',

--- a/src/Execution/CpuDetector.php
+++ b/src/Execution/CpuDetector.php
@@ -27,6 +27,7 @@ class CpuDetector
     private static function detectCpuCount(): int
     {
         foreach (['pthreads_num_cpus', 'pcntl_cpu_count'] as $fn) {
+            // @phpstan-ignore-next-line CI does not have this extension
             if (function_exists($fn)) {
                 $count = @call_user_func($fn);
                 if (is_numeric($count)) {

--- a/src/Execution/CpuDetector.php
+++ b/src/Execution/CpuDetector.php
@@ -27,7 +27,6 @@ class CpuDetector
     private static function detectCpuCount(): int
     {
         foreach (['pthreads_num_cpus', 'pcntl_cpu_count'] as $fn) {
-            // @phpstan-ignore-next-line CI does not have this extension
             if (function_exists($fn)) {
                 $count = @call_user_func($fn);
                 if (is_numeric($count)) {

--- a/src/Orchestrator/TaskOrchestrator.php
+++ b/src/Orchestrator/TaskOrchestrator.php
@@ -93,7 +93,12 @@ final class TaskOrchestrator
                     $options,
                     $queue->pendingCount(),
                     $handlerRegistry,
-                    fn(Throwable $e) => $this->handleStreamException($e, $states, $queue, $output)
+                    function (Throwable $e) use (&$states, $queue, $output) {
+                        $failedId = $this->handleStreamException($e, $states, $queue, $output);
+                        if ($failedId !== null) {
+                            unset($states[$failedId]);
+                        }
+                    }
                 );
                 $output->onTaskStarted($state);
             } else {
@@ -152,9 +157,12 @@ final class TaskOrchestrator
     }
 
     /**
+     * Handle a broken IPC stream by failing the matching task.
+     *
      * @param TaskState[] $states
+     * @return string|null The task ID that was failed, so the caller can drop it from its own state list.
      */
-    public function handleStreamException(Throwable $e, array $states, TaskTreeQueue $queue, ProgressOutput $output): void
+    public function handleStreamException(Throwable $e, array $states, TaskTreeQueue $queue, ProgressOutput $output): ?string
     {
         if (!$e instanceof InvalidStreamException) {
             throw $e;
@@ -163,9 +171,9 @@ final class TaskOrchestrator
             $execution = $state->getExecution();
             if ($execution?->getSession() === $e->getSession()) {
                 $this->onError($state, $queue, $output);
-                unset($states[$state->getTaskId()]);
-                return;
+                return $state->getTaskId();
             }
         }
+        return null;
     }
 }

--- a/src/Tree/TaskTreeQueue.php
+++ b/src/Tree/TaskTreeQueue.php
@@ -117,7 +117,9 @@ final class TaskTreeQueue implements IteratorAggregate
             }
 
             // dispatch it
-            /** @var CompiledTaskNode $task */
+            if ($bestId === null) {
+                throw new LogicException('No available task found despite non-empty availableTasks.');
+            }
             $task = $this->availableTasks[$bestId];
             unset(
                 $this->availableTasks[$bestId],

--- a/src/Tree/TaskTreeQueue.php
+++ b/src/Tree/TaskTreeQueue.php
@@ -117,9 +117,7 @@ final class TaskTreeQueue implements IteratorAggregate
             }
 
             // dispatch it
-            if ($bestId === null) {
-                throw new LogicException('No available task found despite non-empty availableTasks.');
-            }
+            assert($bestId !== null, 'No available task found despite non-empty availableTasks.');
             $task = $this->availableTasks[$bestId];
             unset(
                 $this->availableTasks[$bestId],

--- a/tests/Unit/MultitronFactoryTest.php
+++ b/tests/Unit/MultitronFactoryTest.php
@@ -105,5 +105,20 @@ final class MultitronFactoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $factory->setDefaultConcurrency(-1);
     }
+
+    public function testSetDefaultConcurrencyRejectsZero(): void
+    {
+        $factory = new MultitronFactory($this->createContainer());
+        $this->expectException(InvalidArgumentException::class);
+        $factory->setDefaultConcurrency(0);
+    }
+
+    public function testSetDefaultConcurrencyAllowsNull(): void
+    {
+        $factory = new MultitronFactory($this->createContainer());
+        $factory->setDefaultConcurrency(3);
+        $factory->setDefaultConcurrency(null);
+        $this->assertNull($factory->getDefaultConcurrency());
+    }
 }
 

--- a/tests/Unit/TableRendererTest.php
+++ b/tests/Unit/TableRendererTest.php
@@ -52,6 +52,16 @@ final class TableRendererTest extends TestCase
         $this->assertStringContainsString('<fg=yellow>...</>', $out);
     }
 
+    public function testGetTimeFormatsMinutesAndHoursPadded(): void
+    {
+        $r = $this->createRenderer();
+        $ref = new ReflectionMethod(TableRenderer::class, 'getTime');
+        $ref->setAccessible(true);
+
+        $this->assertStringContainsString('1m05s', $ref->invoke($r, microtime(true) - 65));
+        $this->assertStringContainsString('10:05', $ref->invoke($r, microtime(true) - 605));
+    }
+
     public function testGetLogFormatsTime(): void
     {
         $r = $this->createRenderer();

--- a/tests/Unit/TaskOrchestratorTest.php
+++ b/tests/Unit/TaskOrchestratorTest.php
@@ -110,6 +110,73 @@ final class TaskOrchestratorTest extends TestCase
         );
     }
 
+    public function testStreamExceptionCallbackRemovesFailedTaskFromCallerStates(): void
+    {
+        $session1 = $this->peer->session;
+        $session2 = $this->peer->makeSession();
+
+        $exec1 = new class($session1) implements \Multitron\Execution\Execution {
+            public int $exitCalls = 0;
+
+            public function __construct(private \StreamIpc\IpcSession $session)
+            {
+            }
+
+            public function getSession(): \StreamIpc\IpcSession
+            {
+                return $this->session;
+            }
+
+            public function getExitCode(): ?int
+            {
+                $this->exitCalls++;
+                return null;
+            }
+
+            public function kill(): array
+            {
+                return ['exitCode' => 1, 'stdout' => '', 'stderr' => ''];
+            }
+        };
+        $exec2 = new DummyExecution($session2, 0);
+
+        $capturedCallback = null;
+        $execFactory = $this->createMock(ExecutionFactory::class);
+        $execFactory->method('launch')->willReturnCallback(
+            function (string $commandName, string $taskId, array $options, int $remaining, $registry, ?callable $onException = null) use (&$capturedCallback, $exec1, $exec2, $session1) {
+                if ($taskId === 't1') {
+                    $capturedCallback = $onException;
+                    return new TaskState('t1', $exec1);
+                }
+                // simulate task t1's IPC session breaking while t2 is being launched
+                if ($capturedCallback !== null) {
+                    ($capturedCallback)(new InvalidStreamException($session1));
+                }
+                return new TaskState('t2', $exec2);
+            }
+        );
+
+        $progressFactory = $this->createStub(\Multitron\Orchestrator\Output\ProgressOutputFactory::class);
+        $handlerFactory = $this->createStub(IpcHandlerRegistryFactory::class);
+        $orch = new TaskOrchestrator($this->peer, $execFactory, $progressFactory, $handlerFactory);
+
+        $taskList = new TaskList(new TaskNode('root', null, [
+            new TaskNode('t1', fn() => new \Multitron\Tests\Mocks\DummyTask()),
+            new TaskNode('t2', fn() => new \Multitron\Tests\Mocks\DummyTask()),
+        ]));
+        $queue = new TaskTreeQueue($taskList, 2);
+        $registry = new \Multitron\Execution\Handler\IpcHandlerRegistry();
+
+        $orch->doRun('test', ['update-interval' => 0.01], $queue, $this->output, $registry);
+
+        // t1's execution must never be polled again after the callback already failed it,
+        // otherwise a later non-null exit code would double-fire onTaskCompleted and flip its status back
+        $this->assertSame(1, $exec1->exitCalls);
+        $this->assertCount(2, $this->output->completed);
+        $this->assertSame(TaskStatus::ERROR, $this->output->completed[0]->getStatus());
+        $this->assertSame(TaskStatus::SUCCESS, $this->output->completed[1]->getStatus());
+    }
+
     public function testOnErrorWithSkippedDependencies(): void
     {
         $exec = new DummyExecution($this->peer->session);


### PR DESCRIPTION
## Summary
- `MultitronFactory::setDefaultConcurrency()` now rejects `0` (it previously passed validation but crashed later with an unrelated exception)
- `MultitronExtension` now wires the factory service by reference instead of invoking it at compile time, fixing Nette DI container generation
- `TaskOrchestrator`'s stream-exception handler now correctly removes the failed task from the caller's state list
- Padded seconds in the minute-based duration format (`TableRenderer`)
- Added PHP 8.5 to the CI matrix and bumped `actions/checkout` / `codecov-action`
- Documented the `--low-memory-warn` option in the README
- Updated `SECURITY.md` supported-versions table

## Test plan
- [x] `vendor/bin/phpunit` passes (124 tests)
- [x] PHPStan clean on changed files
- [ ] CI green